### PR TITLE
Adds bash version of `gh`

### DIFF
--- a/functions/gh.bash
+++ b/functions/gh.bash
@@ -1,0 +1,27 @@
+function gh() {
+  if [[ $# -ne 2 ]]; then
+    echo "USAGE: gh [user] [repo]"
+    return
+  fi
+
+  user=$1
+  repo=$2
+
+  user_path=$HOME/src/github.com/$user
+  local_path=$user_path/$repo
+
+  if [[ ! -d $local_path ]]; then
+    git clone git@github.com:$user/$repo.git $local_path
+  fi
+
+  # If git exited uncleanly, clean up the created user directory (if exists)
+  # and don't try to `cd` into it.
+
+  if [[ $? -ne 0 ]]; then
+    if [[ -d $user_path ]]; then
+      rm -d $user_path
+    fi
+  else
+    cd $local_path
+  fi
+}


### PR DESCRIPTION
After reading https://medium.com/@dickeyxxx/the-best-code-ive-ever-written-afaf96f49535#.v8k7kx5ur (and what's up with that URL?) I was pretty stoked to try out `gh`, but alas, I'm still on the bash bandwagon because I'm an old and I was bummed there wasn't a bash version.

But now there is!

It's got some additional edge-case handling (like if the clone fails because you're an idiot and you type `dickyxxx` instead of `dickeyxxx` like 10 times) but other than that it's a pretty straight port.