### PR TITLE
added https support through $GH_PROTO env var

### DIFF
--- a/bash/gh.bash
+++ b/bash/gh.bash
@@ -1,5 +1,5 @@
 GH_BASE_DIR=${GH_BASE_DIR:-$HOME/src}
-GH_PROTO=${GH_PROTO:-"https"}
+GH_PROTO=${GH_PROTO:-"ssh"}
 function gh() {
   if [[ $# -ne 2 ]]; then
     echo "USAGE: gh [user] [repo]"

--- a/bash/gh.bash
+++ b/bash/gh.bash
@@ -1,4 +1,5 @@
 GH_BASE_DIR=${GH_BASE_DIR:-$HOME/src}
+GH_PROTO=${GH_PROTO:-"https"}
 function gh() {
   if [[ $# -ne 2 ]]; then
     echo "USAGE: gh [user] [repo]"
@@ -12,7 +13,13 @@ function gh() {
   local_path=$user_path/$repo
 
   if [[ ! -d $local_path ]]; then
-    git clone git@github.com:$user/$repo.git $local_path
+     if [[ $GH_PROTO == "ssh" ]]; then 
+      git clone git@github.com:$user/$repo.git $local_path
+     elif [[ $GH_PROTO == "https" ]]; then
+      git clone https://github.com/$user/$repo.git $local_path
+     else
+      echo "GH_PROTO must be set to ssh or https"
+    fi
   fi
 
   # If git exited uncleanly, clean up the created user directory (if exists)

--- a/zsh/gh/gh.plugin.zsh
+++ b/zsh/gh/gh.plugin.zsh
@@ -1,6 +1,7 @@
 #Github repo switcher
 
 GH_BASE_DIR=${GH_BASE_DIR:-$HOME/src}
+GH_PROTO=${GH_PROTO:-"https"}
 function gh () {
   typeset +x account=$GITHUB[user]
   typeset +x repo=""
@@ -14,10 +15,16 @@ function gh () {
     echo "USAGE: gh [user] [repo]"
     return 127
   fi
-
+  
   typeset +x directory=$GH_BASE_DIR/github.com/$account/$repo
   if [[ ! -a $directory ]]; then
-    git clone git@github.com:$account/$repo.git $directory
+   if [[ $GH_PROTO == "ssh" ]]; then 
+      git clone git@github.com:$account/$repo.git $directory
+     elif [[ $GH_PROTO == "https" ]]; then
+      git clone https://github.com/$account/$repo.git $directory
+     else
+      echo "GH_PROTO must be set to ssh or https"
+    fi
     if [[ ! -a $directory ]]; then
       return 127
     fi

--- a/zsh/gh/gh.plugin.zsh
+++ b/zsh/gh/gh.plugin.zsh
@@ -1,7 +1,7 @@
 #Github repo switcher
 
 GH_BASE_DIR=${GH_BASE_DIR:-$HOME/src}
-GH_PROTO=${GH_PROTO:-"https"}
+GH_PROTO=${GH_PROTO:-"ssh"}
 function gh () {
   typeset +x account=$GITHUB[user]
   typeset +x repo=""
@@ -15,7 +15,6 @@ function gh () {
     echo "USAGE: gh [user] [repo]"
     return 127
   fi
-  
   typeset +x directory=$GH_BASE_DIR/github.com/$account/$repo
   if [[ ! -a $directory ]]; then
    if [[ $GH_PROTO == "ssh" ]]; then 


### PR DESCRIPTION
I'm unsure how desired this might be from your point of view, but I see #17 open, and being too lazy to set up keys. I figured I'd sort HTTPS out myself.
I saw that you mentioned env vars so I've adjusted what I originally wrote to account for that.
I've tested it in bash and zsh/oh my zosh as I have these on my system and they appear to work as it did originally. I'm unfamiliar with fish and can't test it so daren't touch any of that. 

I decided to allow it to default to https for a few reasons.
- Those that are in the work place may not have access to ssh,
- These same people may not have access to env vars to change that (a problem I've had historically),
- It allows those slightly less literate or lazy to use this, out of the box.

You might have your own reasons to change that, I'll leave you to be the judge.  
Finally I thought I'd say thank you for this, I only discovered it today, but I've already found it incredibly useful!
